### PR TITLE
Add bash completion

### DIFF
--- a/upto.sh
+++ b/upto.sh
@@ -29,3 +29,13 @@ function upto() {
 		return 1
 	fi
 }
+
+# complete upto
+_upto () {
+	# necessary locals for _init_completion
+	local cur prev words cword
+	_init_completion || return
+
+	COMPREPLY+=( $( compgen -W "$( echo ${PWD//\// } )" -- $cur ) )
+}
+complete -F _upto upto


### PR DESCRIPTION
Provides completion relative to $PWD.
Depends on bash_completion and _init_completion being on the system.

Signed-off-by: Gaetan Rivet g.rivet@gmail.com
