### PR TITLE
Only use bash completion if it is available

### DIFF
--- a/upto.sh
+++ b/upto.sh
@@ -38,4 +38,6 @@ _upto () {
 
 	COMPREPLY+=( $( compgen -W "$( echo ${PWD//\// } )" -- $cur ) )
 }
-complete -F _upto upto
+# This complete scheme relies on bash_completion, and the subsequent
+# _init_completion function to work.
+declare -f _init_completion > /dev/null && complete -F _upto upto


### PR DESCRIPTION
Only try to complete upto if _init_completion has been declared.

To test it,
`bash --norc`

Signed-off-by: Gaetan Rivet g.rivet2@gmail.com
